### PR TITLE
added support for varnish-devicedetect

### DIFF
--- a/dts_class_switcher.php
+++ b/dts_class_switcher.php
@@ -84,26 +84,37 @@
 		// DEVICE READING & ALTERNATE THEME OUTPUT
 		// ------------------------------------------------------------------------
 		public function detect_device_and_set_flag () {
-			//Include the MobileESP code library for acertaining device user agents
-			include_once('mdetect.php');
-			
-			//Setup the MobileESP Class
-			$uagent_info = new uagent_info;
-			
-			//Detect if the device is a handheld
-			if ($uagent_info->DetectTierIphone() || $uagent_info->DetectBlackBerry() || $uagent_info->DetectTierRichCss()) : 
-				$this->device_theme = $this->handheld_theme;
-			endif ;
-			
-			//Detect if the device is a tablets
-			if ($uagent_info->DetectTierTablet()) : 
-				$this->device_theme = $this->tablet_theme;
-			endif ;	
-
-			//Detect if the device is a tablets
-			if ($uagent_info->DetectBlackBerryLow() || $uagent_info->DetectTierOtherPhones()) : 
-				$this->device_theme = $this->low_support_theme;
-			endif ;	
+			if (!isset($_SERVER['HTTP_X_UA_DEVICE'])) :
+				//Include the MobileESP code library for acertaining device user agents
+				include_once('mdetect.php');
+				
+				//Setup the MobileESP Class
+				$uagent_info = new uagent_info;
+				
+				//Detect if the device is a handheld
+				if ($uagent_info->DetectTierIphone() || $uagent_info->DetectBlackBerry() || $uagent_info->DetectTierRichCss()) : 
+					$this->device_theme = $this->handheld_theme;
+				endif ;
+				
+				//Detect if the device is a tablets
+				if ($uagent_info->DetectTierTablet()) : 
+					$this->device_theme = $this->tablet_theme;
+				endif ;	
+	
+				//Detect if the device is a tablets
+				if ($uagent_info->DetectBlackBerryLow() || $uagent_info->DetectTierOtherPhones()) : 
+					$this->device_theme = $this->low_support_theme;
+				endif ;	
+			//Support for Varnish Device Detect: https://github.com/varnish/varnish-devicedetect/
+			else :
+				if (in_array($_SERVER['HTTP_X_UA_DEVICE'], array('mobile-iphone', 'mobile-android', 'mobile-smartphone', 'mobile-generic'))) :
+					$this->device_theme = $this->handheld_theme;
+				elseif (in_array($_SERVER['HTTP_X_UA_DEVICE'], array('tablet-ipad', 'tablet-android'))) :
+					$this->device_theme = $this->tablet_theme;
+				else:
+					$this->device_theme = $this->low_support_theme;
+				endif;
+			endif;
 		}//END member function deliver_theme_to_device
 		
 		public function deliver_alternate_device_theme () {


### PR DESCRIPTION
When a site is sitting behind varnish the first device to hit the page sets the uagent_info for that whole page regardless of if a different device hits the same url directly after. The page is cached in varnish (php does not process), so the theme won't change for the next device.  

This change modifies the plugin to rely on $_SERVER['HTTP_X_UA_DEVICE'] and the setup depicted here if it is available: https://github.com/varnish/varnish-devicedetect
This moves device detection into the caching layer so different versions of the page can be cached per device.  If HTTP_X_UA_DEVICE is not available the plugin detects normally.

There is also a patch against -r696222 of http://plugins.svn.wordpress.org/device-theme-switcher/trunk/ here: https://gist.github.com/broderboy/5367090/raw/7a08e41bbef94d68fba25d240cd5a958fc79aa33/gistfile1.diff
