### PR TITLE
Change X-UA-Device detect fallback to active theme

### DIFF
--- a/inc/class.switcher.php
+++ b/inc/class.switcher.php
@@ -51,12 +51,10 @@
 			//Check for Varnish Device Detect: https://github.com/varnish/varnish-devicedetect/
 			//Thanks to Tim Broder for this addition! https://github.com/broderboy | http://timbroder.com/
 			if (isset($_SERVER['HTTP_X_UA_DEVICE'])) :
-				if (in_array($_SERVER['HTTP_X_UA_DEVICE'], array('mobile-iphone', 'mobile-android', 'mobile-smartphone', 'mobile-generic')))
+				if (in_array($_SERVER['HTTP_X_UA_DEVICE'], array('mobile-iphone', 'mobile-android', 'mobile-firefoxos', 'mobile-smartphone', 'mobile-generic')))
 					$device = 'handheld' ;
 				elseif (in_array($_SERVER['HTTP_X_UA_DEVICE'], array('tablet-ipad', 'tablet-android')))
 					$device_theme = $this->tablet_theme;
-				else
-					$device = $low_support_device ;
 			else : //DEFAULT ACTION - Use MobileESP to sniff the UserAgent string
 				//Include the MobileESP code library for acertaining device user agents
 				include_once('mobile-esp.php');


### PR DESCRIPTION
If the detect_device method sees an X-UA-Device header it will attempt to set the theme accordingly. However if it does not find a handheld or tablet device it will default to the mobile theme. This is not desirable as it means the actual desktop theme is never used. The low device support has been removed from the else condition (and firefoxos support added to the mobile group).
