### PR TITLE
Fix recursion bug if dts_cookie_name is not set

### DIFF
--- a/includes/class-switcher.php
+++ b/includes/class-switcher.php
@@ -201,7 +201,7 @@
 			// Ensure our dts_cookie_name option is set
 			$cookie_name = get_option( 'dts_cookie_name' ) ;
 			if ( empty( $cookie_name ) ) {
-				$cookie_name = DTS_Core::get_instance()->build_cookie_name();
+				$cookie_name = DTS_Core::build_cookie_name();
 				update_option( 'dts_cookie_name', $cookie_name );
 			}
 


### PR DESCRIPTION
DTS_Core::get_instance() indirectly calls DTS_Switcher::get_instance() and vice versa if dts_cookie_name is not set. This was causing heavy load on one of my websites after upgrading from an older version of DTS.

Since build_cookie_name() is static, it can be called statically to fix the bug.

This fixes https://wordpress.org/support/topic/server-down-after-updating-to-292-and-wp-41 and https://wordpress.org/support/topic/v292-broken-with-wp-412-urgent-help-needed

A workaround is to add dts_cookie_name to the wp_options table manually.